### PR TITLE
Group improvements

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -13,6 +13,7 @@ en:
     openid_connect_verbose_logging: "Log detailed openid-connect authentication information to `/logs`. Keep this disabled during normal use."
     openid_connect_authorize_parameters: "URL parameters which will be included in the redirect from /auth/oidc to the IDP's authorize endpoint"
     openid_connect_overrides_email: "On every login, override the user's email using the openid-connect value"
+    openid_connect_group_membership_claims: "Auth token claims with group names for a user's group memberships. Format ``name:{modifiers}``."  
   login:
     omniauth_error:
       openid_connect_discovery_error: Unable to fetch configuration from identity provider. Please try again.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,9 +29,6 @@ plugins:
     default: ''
     type: list
     list_type: compact
-  openid_connect_handle_groups:
-    default: false
-  openid_connect_create_groups:
-    default: true
-  openid_connect_strict_groups:
-    default: true
+  openid_connect_group_membership_claims:
+    default: ''
+    type: list

--- a/lib/omniauth_open_id_connect.rb
+++ b/lib/omniauth_open_id_connect.rb
@@ -152,7 +152,7 @@ module ::OmniAuth
           last_name: data_source['family_name'],
           nickname: data_source['preferred_username'],
           image: data_source['picture'],
-          groups: data_source['groups']
+          **group_membership_claims(data_source)
         )
       end
 
@@ -192,7 +192,15 @@ module ::OmniAuth
         response = client.request(:post, options[:client_options][:token_url], body: get_token_options)
         ::OAuth2::AccessToken.from_hash(client, response.parsed)
       end
-
+      
+      def group_membership_claims(data_source)
+        claims = {}
+        SiteSetting.openid_connect_group_membership_claims.split('|').each do |setting|
+          name = setting.rpartition('~~').first
+          claims[name.to_sym] = data_source[name]
+        end
+        claims
+      end
     end
   end
 end

--- a/lib/openid_connect_authenticator.rb
+++ b/lib/openid_connect_authenticator.rb
@@ -78,7 +78,7 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
     
     group_membership_claim_map.each do |gmc|
       if value = association.info[gmc.claim]
-        is_member = value == true ||
+        is_member = [true, "true", "t"].include?(value) ||
           value == gmc.group.name ||
           value.is_a(String) && value.split(',').include?(gmc.group.name)
         


### PR DESCRIPTION
@mattcg This is untested, but the point is to show the direction in which I suggest we take this. Essentially:

1. Have a "map" setting that maps claims in the auth token to groups, with optional modifiers (e.g. for "strict" handling) on a per-group basis.
2. Allow for claims to be in various formats to indicate membership:
    - Boolean, e.g. ``group_name: true``
    - Key/Val, e.g. ``claim_name:group_name``
    - Key/Val list, e.g. ``claim_name:group_name1,group_name2``
3. Require explict handling of group mapping. Allowing groups to be created via claims in an auth token is not a good idea (I doubt it would be accepted) as groups have various settings that need to be determined upon creation.
4. Validate the group claim name before using it on the auth token

If you're on board with this direction we can make sure it works and add tests.